### PR TITLE
Specify PHP versions in Hestia installation

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -115,7 +115,7 @@ install_hestia() {
         --password "$(openssl rand -base64 12)" \
         --port ${HESTIA_PORT} \
         --apache no \
-        --multiphp yes \
+        --multiphp '8.2,8.3,8.4' \
         --mysql yes \
         --postgresql yes \
         --named yes \


### PR DESCRIPTION
Specify PHP versions 8.2, 8.3, and 8.4 in the Hestia installation command in `installer.sh`.

* Modify the `--multiphp` option to include '8.2, 8.3, 8.4' instead of 'yes'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaksws/hestia-odoo-installer/pull/2?shareId=57339876-b7a9-4f80-b05e-42a72da8d8c3).